### PR TITLE
Fix formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
- ```sh # attachmentimages
+# attachmentimages
+```
 image files for discord bot, feel free to use / add more
-``` 
+```
 
-![happy face](https://image.flaticon.com/icons/png/512/42/42829.png)] 
+![happy face](https://image.flaticon.com/icons/png/512/42/42829.png)


### PR DESCRIPTION
Move title out from the codeblock, so it will be displayed.
Remove the unnecesarry `sh` code block formatting, what causes `for` to change color.
Remove the `]` from the end of the link.